### PR TITLE
Add the ability to disable CommandBar

### DIFF
--- a/src/components/shared/editablegrid/editablegrid.tsx
+++ b/src/components/shared/editablegrid/editablegrid.tsx
@@ -66,6 +66,7 @@ export interface Props extends IDetailsListProps {
     enableGridReset?: boolean;
     enableColumnFilterRules?: boolean;
     enableColumnFilters?: boolean;
+    enableCommandBar?: boolean
 }
 
 const EditableGrid = (props: Props) => {
@@ -1245,11 +1246,11 @@ const EditableGrid = (props: Props) => {
                 onChange={onFilterTagListChanged}
             /> : null}
             
-            <CommandBar
+            {props.enableCommandBar === undefined || props.enableCommandBar === true ? <CommandBar
                 items={CommandBarItemProps}
                 ariaLabel="Command Bar"
                 farItems={CommandBarFarItemProps}
-                />
+                /> : null}
             {showSpinner ? 
                 <Spinner label="Updating..." ariaLive="assertive" labelPosition="right" size={SpinnerSize.large}/>
                 :


### PR DESCRIPTION
Hi,

It would be great to have the ability to disable the CommandBar. We have a scenario where we only need the table.
I added an extra property to control this. By default it is set to true so there are no breaking changes.

@kushalmehrotra713 what do you think? Is this something you can accept?

Regards
Christos